### PR TITLE
Add announcement for new version in December 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
 [![Commits since last release](https://img.shields.io/github/commits-since/sympy/sympy/latest.svg?longCache=true&style=flat-square&logo=git&logoColor=fff)](https://github.com/sympy/sympy/releases)
 
 [![SymPy Banner](https://github.com/sympy/sympy/raw/master/banner.svg)](https://sympy.org/)
+## Upcoming Version
+
+We are excited to announce that a new version of SymPy is coming in December 2024! Stay tuned for more updates and features.
 
 
 See the [AUTHORS](AUTHORS) file for the list of authors.


### PR DESCRIPTION
Added a section at the top of the README.md to notify users about an upcoming version of SymPy set for release in December 2024. Placed just below the badges for better visibility. Stay tuned for more updates and features!

Created with `SOLV_R`